### PR TITLE
Fix compiling on Windows, and fix tests against ExactPredicates by refining float range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_predicates.c 
+libpredicates.so
+Manifest.toml
+orient_*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _predicates.c
 libpredicates.so
 Manifest.toml
 orient_*
+output*

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 A Julia port of "Routines for Arbitrary Precision Floating-point Arithmetic and Fast Robust Geometric Predicates"
 by Jonathan Richard Shewchuk. http://www.cs.cmu.edu/~quake/robust.html
 
+Please note that these predicates are only assumed to be correct for floating point numbers with binary exponents in the 
+range $[-141, 201]$. In particular:
+
+> This article does not address issues of overflow and underflow, so I allow the exponent
+to be an integer in the range $[-\infty, \infty]$. (Fortunately, many applications have inputs whose exponents fall
+within a circumscribed range. The four predicates implemented for this article will not overflow nor un-
+derflow if their inputs have exponents in the range $[-142, 201]$ and IEEE 754 double precision arithmetic
+is used.)
+
+- Richard Shewchuk, J. Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates. Discrete Comput Geom 18(3), 305–363 (1997)
+
+If you need predicates outside of this range, ExactPredicates.jl might be preferable.
+
 ## License
 The original code is in the public domain and this Julia port is under the MIT License
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ by Jonathan Richard Shewchuk. http://www.cs.cmu.edu/~quake/robust.html
 Please note that these predicates are only assumed to be correct for floating point numbers with binary exponents in the 
 range $[-141, 201]$. In particular:
 
-> This article does not address issues of overflow and underflow, so I allow the exponent
-to be an integer in the range $[-\infty, \infty]$. (Fortunately, many applications have inputs whose exponents fall
-within a circumscribed range. The four predicates implemented for this article will not overflow nor un-
-derflow if their inputs have exponents in the range $[-142, 201]$ and IEEE 754 double precision arithmetic
-is used.)
+> This article does not address issues of overflow and underflow, so I allow the exponent to be an integer in the range  $[-\infty, \infty]$. (Fortunately, many applications have inputs whose exponents fall within a circumscribed range. The four predicates implemented for this article will not overflow nor underflow if their inputs have exponents in the range $[-142, 201]$ and IEEE 754 double precision arithmetic is used.)
 
 - Richard Shewchuk, J. Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates. Discrete Comput Geom 18(3), 305–363 (1997)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Julia port of "Routines for Arbitrary Precision Floating-point Arithmetic and 
 by Jonathan Richard Shewchuk. http://www.cs.cmu.edu/~quake/robust.html
 
 Please note that these predicates are only assumed to be correct for floating point numbers with binary exponents in the 
-range $[-141, 201]$. In particular:
+range $[-142, 201]$. In particular:
 
 > This article does not address issues of overflow and underflow, so I allow the exponent to be an integer in the range  $[-\infty, \infty]$. (Fortunately, many applications have inputs whose exponents fall within a circumscribed range. The four predicates implemented for this article will not overflow nor underflow if their inputs have exponents in the range $[-142, 201]$ and IEEE 754 double precision arithmetic is used.)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-AdaptivePredicates = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
 ExactPredicates = "429591f6-91af-11e9-00e2-59fbe8cec110"
 Supposition = "5a0628fe-1738-4658-9b6d-0b7605a9755b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,8 +11,8 @@ cd("original") do
             new_pred = replace(pred, "random()" => "rand()")
             write("_predicates.c", new_pred)
             pred_path = "_predicates.c"
-        else 
-            pred_path = "predicates.c" 
+        else
+            pred_path = "predicates.c"
         end
         run(`gcc -shared -fPIC -g2 $pred_path -o libpredicates.so`)
     end
@@ -36,71 +36,68 @@ function orient(a, b, c)
 end
 
 @testset "Spot checks found through Supposition" begin
-    (a,b,c) = (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)
-    @test orient(a,b,c) == ExactPredicates.orient(a,b,c)
-    @test orient(a,b,c) == CPredicates.orient(a, b, c)
+    (a, b, c) = (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)
+    @test orient(a, b, c) == ExactPredicates.orient(a, b, c)
+    @test orient(a, b, c) == CPredicates.orient(a, b, c)
 
     (a, b, c) = (-0.08908073736089261 - 0.1026469210893071im, -1.956194437297279 - 2.254105006193488im, -0.3200306149494339 - 0.36876835836900623im)
-    @test orient(a,b,c) == CPredicates.orient(a, b, c)
-    @test orient(a,b,c) == ExactPredicates.orient(a,b,c)
+    @test orient(a, b, c) == CPredicates.orient(a, b, c)
+    @test orient(a, b, c) == ExactPredicates.orient(a, b, c)
 
-    (a, b, c) = (a = 0.0 + 0.0im, b = 0.0 + 5.0e-324im, c = 5.0e-324 + 2.2536010670724063e30im)
-    @test orient(a,b,c) == CPredicates.orient(a, b, c)
-    @test_broken orient(a,b,c) == ExactPredicates.orient(a,b,c)
+    (a, b, c) = (a=0.0 + 0.0im, b=0.0 + 5.0e-324im, c=5.0e-324 + 2.2536010670724063e30im)
+    @test orient(a, b, c) == CPredicates.orient(a, b, c)
+    @test_broken orient(a, b, c) == ExactPredicates.orient(a, b, c)
 
-    (a,b,c) = (a = 0.0 + 0.0im, b = 0.0 + 5.0e-324im, c = 5.060829986287029e79 + 3.552170572284382e228im)
-    @test orient(a,b,c) == CPredicates.orient(a, b, c)
-    @test_broken orient(a,b,c) == ExactPredicates.orient(a,b,c)
+    (a, b, c) = (a=0.0 + 0.0im, b=0.0 + 5.0e-324im, c=5.060829986287029e79 + 3.552170572284382e228im)
+    @test orient(a, b, c) == CPredicates.orient(a, b, c)
+    @test_broken orient(a, b, c) == ExactPredicates.orient(a, b, c)
 
-    (a, b, c) = (a = 0.0 + 0.0im, b = 0.0 + 5.0e-324im, c = 5.0e-324 + 0.0im)
-    @test orient(a,b,c) == CPredicates.orient(a, b, c)
-    @test_broken orient(a,b,c) == ExactPredicates.orient(a,b,c)
+    (a, b, c) = (a=0.0 + 0.0im, b=0.0 + 5.0e-324im, c=5.0e-324 + 0.0im)
+    @test orient(a, b, c) == CPredicates.orient(a, b, c)
+    @test_broken orient(a, b, c) == ExactPredicates.orient(a, b, c)
 
-    (a,b,c) = (a = 0.0 + 0.0im, b = 0.0 + 5.495397811658139e-246im, c = -4.495267265324774e-79 - 1.382478711138964e-74im)
-    @test orient(a,b,c) == CPredicates.orient(a, b, c)
-    @test orient(a,b,c) == ExactPredicates.orient(a,b,c)
+    (a, b, c) = (a=0.0 + 0.0im, b=0.0 + 5.495397811658139e-246im, c=-4.495267265324774e-79 - 1.382478711138964e-74im)
+    @test orient(a, b, c) == CPredicates.orient(a, b, c)
+    @test orient(a, b, c) == ExactPredicates.orient(a, b, c)
 end
 
 const floatgen = Data.Floats{Float64}()
+const floatgen2 = Data.Floats{Float64}(infs=false, nans=false) # IntervalArithmetic.jl screams out warnings with bad intervals during testing
 const complexgen = @composed function _complex(a=floatgen, b=floatgen)
-    a+b*im
+    a + b * im
+end
+const complexgen2 = @composed function _complex(a=floatgen2, b=floatgen2)
+    a + b * im
 end
 
-# @check function orient_c(a=complexgen, b=complexgen, c=complexgen)
-#     dir = CPredicates.orient(a,b,c)
-#     event!("Adaptive", dir)
-#     edir = CPredicates.orient_exact(a,b,c)
-#     event!("Exact", edir)
-#     dir == edir
-# end
-
 @check function output(a=complexgen, b=complexgen, c=complexgen)
-    orient(a,b,c) ∈ (-1, 0, 1)
+    orient(a, b, c) ∈ (-1, 0, 1)
 end
 
 # Note: This should be true for all, if not this is a bug in the port
 @check function orient_against_c(a=complexgen, b=complexgen, c=complexgen)
-    dir = orient(a,b,c)
+    dir = orient(a, b, c)
     event!("Port", dir)
-    cdir = CPredicates.orient(a,b,c)
+    cdir = CPredicates.orient(a, b, c)
     event!("Original", cdir)
     dir == cdir
 end
 
 # The next two should agree
-@check function orient_against_exact(a=complexgen, b=complexgen, c=complexgen)
-    dir = orient(a,b,c)
+@check function orient_against_exact(a=complexgen2, b=complexgen2, c=complexgen2)
+    assume!(all(x -> iszero(x) || exponent(abs(x)) ∈ -141:201, (a.re, a.im, b.re, b.im, c.re, c.im)))
+    dir = orient(a, b, c)
     event!("Adaptive", dir)
-    edir = ExactPredicates.orient(a,b,c)
+    edir = ExactPredicates.orient(a, b, c)
     event!("Exact", edir)
     dir == edir
 end
 
-@check function orient_c_against_exact(a=complexgen, b=complexgen, c=complexgen)
-    dir = CPredicates.orient(a,b,c)
+@check function orient_c_against_exact(a=complexgen2, b=complexgen2, c=complexgen2)
+    assume!(all(x -> iszero(x) || exponent(abs(x)) ∈ -141:201, (a.re, a.im, b.re, b.im, c.re, c.im)))
+    dir = CPredicates.orient(a, b, c)
     event!("Original", dir)
-    edir = ExactPredicates.orient(a,b,c)
+    edir = ExactPredicates.orient(a, b, c)
     event!("Exact", edir)
     dir == edir
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,8 +84,11 @@ end
 end
 
 # The next two should agree
+check_range(x) = iszero(x) || exponent(abs(x)) ∈ -141:201   # Shewchuk's predicates are only guaranteed to be accurate for floats with binary 
+                                                            # exponents in the range [-141, 201]. See Section 2.1 in the paper 
+                                                            # Richard Shewchuk, J. Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates. Discrete Comput Geom 18(3), 305–363 (1997)
 @check function orient_against_exact(a=complexgen2, b=complexgen2, c=complexgen2)
-    assume!(all(x -> iszero(x) || exponent(abs(x)) ∈ -141:201, (a.re, a.im, b.re, b.im, c.re, c.im)))
+    assume!(all(check_range, (a.re, a.im, b.re, b.im, c.re, c.im)))
     dir = orient(a, b, c)
     event!("Adaptive", dir)
     edir = ExactPredicates.orient(a, b, c)
@@ -94,7 +97,7 @@ end
 end
 
 @check function orient_c_against_exact(a=complexgen2, b=complexgen2, c=complexgen2)
-    assume!(all(x -> iszero(x) || exponent(abs(x)) ∈ -141:201, (a.re, a.im, b.re, b.im, c.re, c.im)))
+    assume!(all(check_range, (a.re, a.im, b.re, b.im, c.re, c.im)))
     dir = CPredicates.orient(a, b, c)
     event!("Original", dir)
     edir = ExactPredicates.orient(a, b, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,8 +84,8 @@ end
 end
 
 # The next two should agree
-check_range(x) = iszero(x) || exponent(abs(x)) ∈ -141:201   # Shewchuk's predicates are only guaranteed to be accurate for floats with binary 
-                                                            # exponents in the range [-141, 201]. See Section 2.1 in the paper 
+check_range(x) = iszero(x) || exponent(abs(x)) ∈ -142:201   # Shewchuk's predicates are only guaranteed to be accurate for floats with binary 
+                                                            # exponents in the range [-142, 201]. See Section 2.1 in the paper 
                                                             # Richard Shewchuk, J. Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates. Discrete Comput Geom 18(3), 305–363 (1997)
 @check function orient_against_exact(a=complexgen2, b=complexgen2, c=complexgen2)
     assume!(all(check_range, (a.re, a.im, b.re, b.im, c.re, c.im)))


### PR DESCRIPTION
Fixes #4. Since the algorithms are said to be guaranteed correct only for exponents in $[-142, 201]$, the tests against ExactPredicates now only test in this range. 

I accidentally included my Windows fixes in this branch so I closed #3 and am using this for both. Hopefully that's fine. 