### PR TITLE
Fix bug in predicates.c

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -343,3 +343,13 @@ end
     x7, x6 = Two_Sum(_m, _k)
     return x7, x6, x5, x4, x3, x2, x1, x0
 end
+
+function Two_Square(a1, a0)
+    _j, x0 = Square(a0)
+    _0 = a0 + a0
+    _k, _1 = Two_Product(a1, _0)
+    _l, _2, x1 = Two_One_Sum(_k, _1, _j)
+    _j, _1 = Square(a1)
+    x5, x4, x3, x2 = Two_Two_Sum(_j, _1, _l, _2)
+    return x5, x4, x3, x2, x1, x0
+end

--- a/test/original/CPredicates.jl
+++ b/test/original/CPredicates.jl
@@ -219,5 +219,9 @@ end
         a3, a2, a1, a0 = _rand(4)
         @test AdaptivePredicates.Two_Two_Product(a3, a2, a1, a0) ==
               @ccall libpredicates._Two_Two_Product(a3::F64, a2::F64, a1::F64, a0::F64)::NTuple{8,Cdouble}
+
+        a1, a0 = _rand(2)
+        @test AdaptivePredicates.Two_Square(a1, a0) ==
+              @ccall libpredicates.Two_Square(a1::F64, a0::F64)::NTuple{6,Cdouble}
     end
 end

--- a/test/original/CPredicates.jl
+++ b/test/original/CPredicates.jl
@@ -222,6 +222,6 @@ end
 
         a1, a0 = _rand(2)
         @test AdaptivePredicates.Two_Square(a1, a0) ==
-              @ccall libpredicates.Two_Square(a1::F64, a0::F64)::NTuple{6,Cdouble}
+              @ccall libpredicates._Two_Square(a1::F64, a0::F64)::NTuple{6,Cdouble}
     end
 end

--- a/test/original/macro_defs.c
+++ b/test/original/macro_defs.c
@@ -1265,16 +1265,16 @@ int TestTwoTwoProduct()
 
 /**********************************************/
 #define Two_Square(a1, a0, x5, x4, x3, x2, x1, x0) \
-  Square(a0, _j, x0);                              \
-  _0 = a0 + a0;                                    \
-  Two_Product(a1, _0, _k, _1);                     \
-  Two_One_Sum(_k, _1, _j, _l, _2, x1);             \
-  Square(a1, _j, _1);                              \
-  Two_Two_Sum(_j, _1, _l, _2, x5, x4, x3, x2)
+  Square(a0, _1, x0);                              \
+  _2 = a0 + a0;                                    \
+  Two_Product(a1, _2, _3, _4);                     \
+  Two_One_Sum(_3, _4, _1, _5, _6, x1);             \
+  Square(a1, _7, _8);                              \
+  Two_Two_Sum(_7, _8, _5, _6, x5, x4, x3, x2);
 
 RealTuple6 _Two_Square(REAL a1, REAL a0)
 {
-  REAL x5, x4, x3, x2, x1, x0, _i, _j, _0, _1, _2, c, abig, ahi, alo, err1, err2, err3, avirt, bvirt, around, bround, _k, bhi, blo, _l;
+  REAL x5, x4, x3, x2, x1, x0, _i, _j, _0, _1, _2, _3, _4, _5, _6, _7, _8, c, abig, ahi, alo, err1, err2, err3, avirt, bvirt, around, bround, _k, bhi, blo, _l;
   Two_Square(a1, a0, x5, x4, x3, x2, x1, x0);
   RealTuple6 result = {x5, x4, x3, x2, x1, x0};
   return result;
@@ -1287,7 +1287,7 @@ int TestTwoSquare()
   {
     rand2(L, R);
     RealTuple6 lhs = _Two_Square(aa, bb);
-    REAL x5, x4, x3, x2, x1, x0, _i, _j, _0, _1, _2, c, abig, ahi, alo, err1, err2, err3, avirt, bvirt, around, bround, _k, bhi, blo, _l;
+    REAL x5, x4, x3, x2, x1, x0, _i, _j, _0, _1, _2, _3, _4, _5, _6, _7, _8, c, abig, ahi, alo, err1, err2, err3, avirt, bvirt, around, bround, _k, bhi, blo, _l;
     Two_Square(aa, bb, x5, x4, x3, x2, x1, x0);
     RealTuple6 rhs = {x5, x4, x3, x2, x1, x0};
     int test = CompareTuples6(lhs, rhs);

--- a/test/original/macro_defs.txt
+++ b/test/original/macro_defs.txt
@@ -348,9 +348,17 @@ RealTuple8 _Two_Two_Product(REAL a1, REAL a0, REAL b1, REAL b0)
   return result;
 }
 
+#define Two_Square(a1, a0, x5, x4, x3, x2, x1, x0) \
+  Square(a0, _1, x0);                              \
+  _2 = a0 + a0;                                    \
+  Two_Product(a1, _2, _3, _4);                     \
+  Two_One_Sum(_3, _4, _1, _5, _6, x1);             \
+  Square(a1, _7, _8);                              \
+  Two_Two_Sum(_7, _8, _5, _6, x5, x4, x3, x2);
+
 RealTuple6 _Two_Square(REAL a1, REAL a0)
 {
-  REAL x5, x4, x3, x2, x1, x0, _i, _j, _0, _1, _2, c, abig, ahi, alo, err1, err2, err3, avirt, bvirt, around, bround, _k, bhi, blo, _l;
+  REAL x5, x4, x3, x2, x1, x0, _i, _j, _0, _1, _2, _3, _4, _5, _6, _7, _8, c, abig, ahi, alo, err1, err2, err3, avirt, bvirt, around, bround, _k, bhi, blo, _l;
   Two_Square(a1, a0, x5, x4, x3, x2, x1, x0);
   RealTuple6 result = {x5, x4, x3, x2, x1, x0};
   return result;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,13 @@ cd("original") do
         pred = read("predicates.c", String)
         if Sys.iswindows()
             # random(), being a POSIX function, is not available on Windows. We need to use rand().
-            new_pred = replace(pred, "random()" => "rand()")
+            new_pred = replace(pred, "random()" => "rand()", "#define Two_Square" => "#define Old_Two_Square")
             write("_predicates.c", new_pred)
         else
+            new_pred = replace(pred, "#define Two_Square" => "#define Old_Two_Square")
             write("_predicates.c", pred)
         end
+        
         ## Append function definitions of the macros to pred_path, allowing for them to be 
         ## @ccalled for the purpose of testing 
         open("_predicates.c", "a") do io


### PR DESCRIPTION
In `predicates.c` (the original code!), there is a bug in the (unused) `Two_Square` where it reuses a temporary variable mistakenly. This has now been fixed.