### PR TITLE
Remove `public` marker from exported symbols

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdaptivePredicates"
 uuid = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
 authors = ["Valentin Churavy <v.churavy@gmail.com> and Daniel VandenHeuvel <danj.vandenheuvel@gmail.com"]
-version = "1.1.0"
+version = "1.1.1"
 
 [compat]
 julia = "1.6"

--- a/src/AdaptivePredicates.jl
+++ b/src/AdaptivePredicates.jl
@@ -10,8 +10,4 @@ export orient2, orient3, incircle, insphere
 export orient2p, orient3p, incirclep, inspherep
 export orient2fast, orient3fast, incirclefast, inspherefast
 
-@static if VERSION ≥ v"1.11.0-DEV.469"
-    eval(Meta.parse("public orient2, orient3, incircle, insphere, orient2p, orient3p, incirclep, inspherep, orient2fast, orient3fast, incirclefast, inspherefast"))
-end
-
 end # module


### PR DESCRIPTION
Otherwise loading the package on nightly gives errors like: `LoadError: cannot declare AdaptivePredicates.orient2 public; it is already declared exported`. Exported symbols are implicitly marked as public so it shouldn't be necessary anyway.

Would it be possible to make a new release when this is merged? Otherwise it's not possible to install any dependent packages on nightly like Makie/DelaunayTriangulation.